### PR TITLE
Remove setting of PKG_LIBS and CXX_STD

### DIFF
--- a/R-package/src/Makevars
+++ b/R-package/src/Makevars
@@ -7,6 +7,3 @@
 #CXX_STD = CXX11
 
 PKG_CPPFLAGS = -I../../include/graph_spme
-PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
-#PKG_CXXFLAGS = -std=c++11
-CXX_STD = CXX11


### PR DESCRIPTION
Not necessary according according to comments in Makevars,
and might even cause failure to build R-package on some systems.