### PR TITLE
Find precision elements from neighbourhood matrix and Markov order

### DIFF
--- a/GraphSPME-examples/ar1_assimilation.R
+++ b/GraphSPME-examples/ar1_assimilation.R
@@ -39,7 +39,7 @@ for(psi in psi_values){
                          rep(1,p-1))
     )
     mu_t1_t0 <- colMeans(mu_t1_t0_sample)
-    prec_t1_t0 <- prec_sparse(mu_t1_t0_sample, Z, shrinkage = TRUE)
+    prec_t1_t0 <- prec_sparse(mu_t1_t0_sample, Graph=Z, markov_order = 1, shrinkage = TRUE)
     prec_t1_t0
     nu_t1_t0 <- prec_t1_t0 %*% mu_t1_t0
 

--- a/R-package/R/RcppExports.R
+++ b/R-package/R/RcppExports.R
@@ -9,8 +9,8 @@
     .Call(`_GraphSPME__sparse_matrix_inverse`, A)
 }
 
-.prec_sparse <- function(x, Z, cov_shrinkage = TRUE) {
-    .Call(`_GraphSPME__prec_sparse`, x, Z, cov_shrinkage)
+.prec_sparse <- function(x, Neighbours, markov_order = 1L, cov_shrinkage = TRUE) {
+    .Call(`_GraphSPME__prec_sparse`, x, Neighbours, markov_order, cov_shrinkage)
 }
 
 .cov_ml <- function(x) {
@@ -19,5 +19,9 @@
 
 .create_bi <- function(Z, j) {
     .Call(`_GraphSPME__create_bi`, Z, j)
+}
+
+.get_precision_nonzero <- function(Graph, markov_order) {
+    .Call(`_GraphSPME__get_precision_nonzero`, Graph, markov_order)
 }
 

--- a/R-package/R/prec_sparse.R
+++ b/R-package/R/prec_sparse.R
@@ -8,16 +8,32 @@
 #' \code{prec_sparse} is the precision matrix estimator in \pkg{GraphSPME}.
 #'
 #' @param X an \eqn{nxp} matrix with \eqn{n-}observations of a \eqn{p-}vector
-#' @param Z a sparse matrix indicating non-zero elements of the precision matrix
-#' @param shrinkage if shrinkage should be applied to block-frequentist-covariance see details for more
+#' @param Graph a \eqn{pxp} sparse matrix representing a graph with vertices
+#' corresponding to columns of \code{X} and edges to direct connections
+#' (neighborhood) between columns of \code{X}
+#' @param markov_order non-negative int representing the markov order of data
+#' \code{X} wrt \code{Graph}
+#' @param shrinkage if shrinkage should be applied to
+#' block-frequentist-covariance see details for more
 #'
 #' @details
 #'
-#' The algorithm utilizes the knowledge of the sparsity provided through
-#' \code{Z}, using the algorithm of Le (2021). If \code{shrinkage=TRUE} then
+#' The algorithm utilizes the knowledge of the graph provided through
+#' \code{Graph} and \code{markov_order} to create sparse matrix \code{Z} indicating the
+#' non-zero elements of the precision matrix of \code{X}.
+#'
+#' The resulting sparse matrix \code{Z} is then utilized to estimate a sparse
+#' precision matrix using the algorithm of Le (2021).
+#'
+#' If \code{shrinkage=TRUE} then
 #' the method of Le (2021) is modified by the method in
 #' Lunde (2022) to iteratively employ asymptotic shrinkage when building
 #' the sparse precision matrix estimator.
+#'
+#' Employing shrinkage ensures numerical stability while improving the resulting
+#' precision/covariance estimate. This is particularly noticeable when the
+#' problem involves many neighbors for each vertex and/or has a high Markov
+#' order.
 #'
 #' The algorithm should be robust in the face of extremely high dimensions.
 #'
@@ -29,20 +45,26 @@
 #'
 #' @rdname prec_sparse
 #' @export
-prec_sparse <- function(X, Z, shrinkage = TRUE) {
+prec_sparse <- function(X, Graph, markov_order = 1, shrinkage = TRUE) {
   # check xtype
   if (!is.matrix(X)) {
     stop("X must be a matrix")
   }
   # dimensions
-  if (!all(ncol(X) == dim(Z))) {
-    stop("ncol(X) must equal both dim(Z)")
+  if (!all(ncol(X) == dim(Graph))) {
+    stop("ncol(X) must equal both dim(Graph)")
   }
   # sparsity type
-  if (!(class(Z) == "dgCMatrix")) {
-    stop("Z must be a sparse matrix of type dgCMatrix")
+  if (!(class(Graph) == "dgCMatrix")) {
+    stop("Graph must be a sparse matrix of type dgCMatrix")
+  }
+  # markov order
+  is.wholenumber <-
+    function(x, tol = .Machine$double.eps^0.5) abs(x - round(x)) < tol
+  if (!is.numeric(markov_order) || !is.wholenumber(markov_order) || markov_order < 0) {
+    stop("markov_order must be a non-negative whole number")
   }
 
   # calculate precision
-  return(.prec_sparse(X, Z, shrinkage))
+  return(.prec_sparse(X, Graph, markov_order, shrinkage))
 }

--- a/R-package/man/cov_shrink_spd.Rd
+++ b/R-package/man/cov_shrink_spd.Rd
@@ -17,7 +17,7 @@ Dense covariance matrix that is SPD.
 }
 \details{
 The standard frequentist covariance matrix estimate is calculated.
-Using techniques of Touloumis (2015) the matrix is shrunk towards a 
+Using techniques of Touloumis (2015) the matrix is shrunk towards a
 sparse target matrix, set to be the diagonal matrix of the frequentist
 estimate. The amount of shrinkage is found using asymptotic results
 found in the reference paper.

--- a/R-package/man/prec_sparse.Rd
+++ b/R-package/man/prec_sparse.Rd
@@ -4,14 +4,20 @@
 \alias{prec_sparse}
 \title{Graphical Sparse Precision Matrix Estimation}
 \usage{
-prec_sparse(x, Z, shrinkage = TRUE)
+prec_sparse(X, Graph, markov_order = 1, shrinkage = TRUE)
 }
 \arguments{
-\item{x}{an \eqn{nxp} matrix with \eqn{n-}observations of a \eqn{p-}vector}
+\item{X}{an \eqn{nxp} matrix with \eqn{n-}observations of a \eqn{p-}vector}
 
-\item{Z}{a sparse matrix indicating non-zero elements of the precision matrix}
+\item{Graph}{a \eqn{pxp} sparse matrix representing a graph with vertices
+corresponding to columns of \code{X} and edges to direct connections
+(neighborhood) between columns of \code{X}}
 
-\item{shrinkage}{if shrinkage should be applied to block-frequentist-covariance see details for more}
+\item{markov_order}{non-negative int representing the markov order of data
+\code{X} wrt \code{Graph}}
+
+\item{shrinkage}{if shrinkage should be applied to
+block-frequentist-covariance see details for more}
 }
 \value{
 Sparse precision matrix that is SPD.
@@ -20,11 +26,22 @@ Sparse precision matrix that is SPD.
 \code{prec_sparse} is the precision matrix estimator in \pkg{GraphSPME}.
 }
 \details{
-The algorithm utilizes the knowledge of the sparsity provided through
-\code{Z}, using the algorithm of Le (2021). If \code{shrinkage=TRUE} then
-the method of Le (2021) is modified by the method in 
+The algorithm utilizes the knowledge of the graph provided through
+\code{Graph} and \code{markov_order} to create sparse matrix \code{Z} indicating the 
+non-zero elements of the precision matrix of \code{X}.
+
+The resulting sparse matrix \code{Z} is then utilized to estimate a sparse 
+precision matrix using the algorithm of Le (2021). 
+
+If \code{shrinkage=TRUE} then
+the method of Le (2021) is modified by the method in
 Lunde (2022) to iteratively employ asymptotic shrinkage when building
 the sparse precision matrix estimator.
+
+Employing shrinkage ensures numerical stability while improving the resulting
+precision/covariance estimate. This is particularly noticeable when the
+problem involves many neighbors for each vertex and/or has a high Markov
+order.
 
 The algorithm should be robust in the face of extremely high dimensions.
 }

--- a/R-package/src/RcppExports.cpp
+++ b/R-package/src/RcppExports.cpp
@@ -34,15 +34,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // _prec_sparse
-Eigen::SparseMatrix<double> _prec_sparse(Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic>& x, Eigen::SparseMatrix<double>& Z, bool cov_shrinkage);
-RcppExport SEXP _GraphSPME__prec_sparse(SEXP xSEXP, SEXP ZSEXP, SEXP cov_shrinkageSEXP) {
+Eigen::SparseMatrix<double> _prec_sparse(Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic>& x, Eigen::SparseMatrix<double>& Neighbours, int markov_order, bool cov_shrinkage);
+RcppExport SEXP _GraphSPME__prec_sparse(SEXP xSEXP, SEXP NeighboursSEXP, SEXP markov_orderSEXP, SEXP cov_shrinkageSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic>& >::type x(xSEXP);
-    Rcpp::traits::input_parameter< Eigen::SparseMatrix<double>& >::type Z(ZSEXP);
+    Rcpp::traits::input_parameter< Eigen::SparseMatrix<double>& >::type Neighbours(NeighboursSEXP);
+    Rcpp::traits::input_parameter< int >::type markov_order(markov_orderSEXP);
     Rcpp::traits::input_parameter< bool >::type cov_shrinkage(cov_shrinkageSEXP);
-    rcpp_result_gen = Rcpp::wrap(_prec_sparse(x, Z, cov_shrinkage));
+    rcpp_result_gen = Rcpp::wrap(_prec_sparse(x, Neighbours, markov_order, cov_shrinkage));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -69,13 +70,26 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// _get_precision_nonzero
+Eigen::SparseMatrix<double> _get_precision_nonzero(Eigen::SparseMatrix<double>& Graph, int markov_order);
+RcppExport SEXP _GraphSPME__get_precision_nonzero(SEXP GraphSEXP, SEXP markov_orderSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Eigen::SparseMatrix<double>& >::type Graph(GraphSEXP);
+    Rcpp::traits::input_parameter< int >::type markov_order(markov_orderSEXP);
+    rcpp_result_gen = Rcpp::wrap(_get_precision_nonzero(Graph, markov_order));
+    return rcpp_result_gen;
+END_RCPP
+}
 
 static const R_CallMethodDef CallEntries[] = {
     {"_GraphSPME__cov_shrink_spd", (DL_FUNC) &_GraphSPME__cov_shrink_spd, 1},
     {"_GraphSPME__sparse_matrix_inverse", (DL_FUNC) &_GraphSPME__sparse_matrix_inverse, 1},
-    {"_GraphSPME__prec_sparse", (DL_FUNC) &_GraphSPME__prec_sparse, 3},
+    {"_GraphSPME__prec_sparse", (DL_FUNC) &_GraphSPME__prec_sparse, 4},
     {"_GraphSPME__cov_ml", (DL_FUNC) &_GraphSPME__cov_ml, 1},
     {"_GraphSPME__create_bi", (DL_FUNC) &_GraphSPME__create_bi, 2},
+    {"_GraphSPME__get_precision_nonzero", (DL_FUNC) &_GraphSPME__get_precision_nonzero, 2},
     {NULL, NULL, 0}
 };
 

--- a/R-package/src/graph_spme.cpp
+++ b/R-package/src/graph_spme.cpp
@@ -35,10 +35,11 @@ Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic> _sparse_matrix_inverse(Eigen
 // [[Rcpp::export(.prec_sparse)]]
 Eigen::SparseMatrix<double> _prec_sparse(
         Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic>& x,
-        Eigen::SparseMatrix<double>& Z,
+        Eigen::SparseMatrix<double>& Neighbours,
+        int markov_order=1,
         bool cov_shrinkage=true
 ){
-    return prec_sparse(x, Z, cov_shrinkage);
+    return prec_sparse(x, Neighbours, markov_order, cov_shrinkage);
 }
 
 // [[Rcpp::export(.cov_ml)]]
@@ -49,4 +50,9 @@ Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic> _cov_ml(Eigen::Matrix<double
 // [[Rcpp::export(.create_bi)]]
 Eigen::SparseMatrix<double> _create_bi(Eigen::SparseMatrix<double>& Z, int j) {
     return create_bi(Z, j);
+}
+
+// [[Rcpp::export(.get_precision_nonzero)]]
+Eigen::SparseMatrix<double> _get_precision_nonzero(Eigen::SparseMatrix<double>& Graph, int markov_order) {
+    return get_precision_nonzero(Graph, markov_order);
 }

--- a/R-package/tests/testthat/test_get_precision_nonzero.R
+++ b/R-package/tests/testthat/test_get_precision_nonzero.R
@@ -1,0 +1,24 @@
+# Tests for GraphSPME:::.get_precision_nonzero()
+library(GraphSPME)
+library(Matrix)
+
+p <- 10
+Neighbours <- bandSparse(
+  p, p,
+  (-1):1,
+  list(
+    rep(1, p - 1),
+    rep(1, p),
+    rep(1, p - 1)
+  )
+)
+
+Ip <- as(diag(p), "dgCMatrix")
+
+test_that("get_precision_nonzero returns identity at markov order 0", {
+  expect_equal(GraphSPME:::.get_precision_nonzero(Neighbours, 0), Ip)
+})
+
+test_that("get_precision_nonzero returns Neighbours at markov order 1", {
+  expect_equal(GraphSPME:::.get_precision_nonzero(Neighbours, 1), Neighbours)
+})

--- a/R-package/tests/testthat/test_prec_sparse.R
+++ b/R-package/tests/testthat/test_prec_sparse.R
@@ -6,29 +6,53 @@ library(Matrix)
 p <- 10
 n <- 100
 X <- matrix(rnorm(p * n), nrow = n, ncol = p)
-Z <- bandSparse(p, p, 0:0, list(rep(1, p)))
-Z_wrong_sparsity <- as(Z, "dtCMatrix") # ensure wrong sparsity class
-Z_correct_sparsity <- as(Z, "dgCMatrix") # ensure correct sparsity class
+Graph <- bandSparse(p, p, 0:0, list(rep(1, p)))
+Graph_wrong_sparsity <- as(Graph, "dtCMatrix") # ensure wrong sparsity class
+Graph_correct_sparsity <- as(Graph, "dgCMatrix") # ensure correct sparsity class
 
 test_that("R throws an error for wrong sparsity type", {
   expect_error(
-    prec_sparse(X, Z_wrong_sparsity),
-    "Z must be a sparse matrix of type dgCMatrix"
+    prec_sparse(X, Graph_wrong_sparsity),
+    "Graph must be a sparse matrix of type dgCMatrix"
   )
 })
 
 test_that("R throws an error for wrong data input type", {
   X_df <- data.frame(X)
   expect_error(
-    prec_sparse(X_df, Z_correct_sparsity),
+    prec_sparse(X_df, Graph_correct_sparsity),
     "X must be a matrix"
   )
 })
 
 test_that("R throws an error when data and neighbourhood structure does not match", {
   X_extended <- cbind(X, rnorm(n))
-  expect_error(prec_sparse(X_extended, Z_correct_sparsity),
-    "ncol(X) must equal both dim(Z)",
+  expect_error(prec_sparse(X_extended, Graph_correct_sparsity),
+    "ncol(X) must equal both dim(Graph)",
     fixed = TRUE
+  )
+})
+
+test_that("R throws an error for wrong input type in markov_order", {
+  markov_order <- "string"
+  expect_error(
+    prec_sparse(X, Graph_correct_sparsity, markov_order),
+    "markov_order must be a non-negative whole number"
+  )
+})
+
+test_that("R throws an error for wrong numeric type in markov_order", {
+  markov_order <- 1.2
+  expect_error(
+    prec_sparse(X, Graph_correct_sparsity, markov_order),
+    "markov_order must be a non-negative whole number"
+  )
+})
+
+test_that("R throws an error for negative int in markov_order", {
+  markov_order <- -1
+  expect_error(
+    prec_sparse(X, Graph_correct_sparsity, markov_order),
+    "markov_order must be a non-negative whole number"
   )
 })

--- a/python-package/src/graphspme/__init__.py
+++ b/python-package/src/graphspme/__init__.py
@@ -16,12 +16,13 @@ else:
 
 def prec_sparse(
     x: NDArray,
-    Z: scipy.sparse.csr_matrix,
+    Graph: scipy.sparse.csr_matrix,
+    markov_order: int = 1,
     cov_shrinkage: bool = True,
 ) -> scipy.sparse.csr_matrix:
-    if not scipy.sparse.isspmatrix_csr(Z):
+    if not scipy.sparse.isspmatrix_csr(Graph):
         raise ValueError(
-            "Z matrix is not on csr (Compressed Sparse Row) format. "
+            "Graph matrix is not on csr (Compressed Sparse Row) format. "
             "This is usually solved by adding format='csr' to the"
             "matrix initialization, e.g. identity(n=10, format='csr')"
         )
@@ -30,12 +31,17 @@ def prec_sparse(
             f"x should be a two dimensional matrix, but has shape: {x.shape}"
         )
     _, n = x.shape
-    if Z.shape != (n, n):
+    if Graph.shape != (n, n):
         raise ValueError(
-            "If x has shape (p,n) then Z should have shape (n,n), "
-            f"but got x.shape = {x.shape} and Z.shape = {Z.shape}"
+            "If x has shape (p,n) then Graph should have shape (n,n), "
+            f"but got x.shape = {x.shape} and Graph.shape = {Graph.shape}"
         )
-    return _prec_sparse(x, Z, cov_shrinkage)
+    if not isinstance(markov_order, int) or markov_order < 0:
+        raise ValueError(
+            "markov_order should be a non-negative integer, "
+            f"but got markov_order = {markov_order}"
+        )
+    return _prec_sparse(x, Graph, markov_order, cov_shrinkage)
 
 
 def cov_shrink_spd(x: NDArray) -> NDArray:

--- a/python-package/tests/test_prec_sparse.py
+++ b/python-package/tests/test_prec_sparse.py
@@ -7,26 +7,27 @@ import graphspme
 
 def test_prec_sparse_non_csr():
     x = np.tile(np.ones([4]), (4, 1))
-    Z = sparse.diags([1, 1, 1, 1], 0, format="csc")
+    Graph = sparse.diags([1, 1, 1, 1], 0, format="csc")
     with pytest.raises(
-        ValueError, match=r".*Z matrix is not on csr \(Compressed Sparse Row\) format.*"
+        ValueError,
+        match=r".*Graph matrix is not on csr \(Compressed Sparse Row\) format.*",
     ):
-        graphspme.prec_sparse(x, Z)
+        graphspme.prec_sparse(x, Graph)
 
 
 @pytest.mark.parametrize(
     "x", [np.ones(shape=(5,)), np.random.normal(0, 1, size=(5, 3, 5))]
 )
 def test_prec_sparse_x_wrong_dimensions(x):
-    Z = sparse.diags([1, 1, 1], 0, format="csr")
+    Graph = sparse.diags([1, 1, 1], 0, format="csr")
     with pytest.raises(ValueError, match=r".*x should be a two dimensional matrix.*"):
-        graphspme.prec_sparse(x, Z)
+        graphspme.prec_sparse(x, Graph)
 
 
 def test_prec_sparse_dimension_mismatch():
     x = np.tile(np.ones([4]), (4, 1))
-    Z = sparse.diags([1, 1, 1], 0, format="csr")
+    Graph = sparse.diags([1, 1, 1], 0, format="csr")
     with pytest.raises(
-        ValueError, match=r".*but got x.shape = \(4, 4\) and Z.shape = \(3, 3\)"
+        ValueError, match=r".*but got x.shape = \(4, 4\) and Graph.shape = \(3, 3\)"
     ):
-        graphspme.prec_sparse(x, Z)
+        graphspme.prec_sparse(x, Graph)


### PR DESCRIPTION
Resolves #29

**Approach**
- [x] Make a `get_precision_from_neighbours_and_markov()`-type function
- [x] Write a test: It should return identity at markov order 0, and the neighbourhood matrix at markov order 1
- [x] Use function inside of `prec_sparse()` - this require API-change
- [x] Fix R and Py API