### PR TITLE
Add deprecation note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 [![Wheels](https://github.com/equinor/GraphSPME/actions/workflows/wheels.yml/badge.svg)](https://github.com/equinor/GraphSPME/actions/workflows/wheels.yml)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
+> :warning: **The GraphSPME project was archived on 2026-02-03. It has been
+> superseded by [Graphite Maps](https://github.com/equinor/graphite-maps), and
+> this repository is now deprecated and no longer maintained.**
+
 **High dimensional precision matrix estimation with a known graphical structure**
 
 - [x] Works in very high dimensions


### PR DESCRIPTION
Closes https://github.com/equinor/GraphSPME/issues/66.

[Preview of how the change looks](https://github.com/ajaust/GraphSPME/blob/prepare-archivation/README.md)

We might have to update the date before merging.

After this PR is merged, somebody with sufficient permissions (not me) needs to archive the repository in the GitHub settings.